### PR TITLE
Fixed issues with RT link

### DIFF
--- a/js/ratings.js
+++ b/js/ratings.js
@@ -296,7 +296,7 @@ function getTomatoLink(rating, callback) {
     if (cached.inCache && cached.cachedVal.tomatoAliasUrl !== undefined) {
         callback(rating);
     } else {
-        var tomatoAliasUrl = null;
+        var tomatoAliasUrl = "";
         $.get(getTomatoAPILink(imdbID), function(res) {
             if (res.error === undefined) {
                 tomatoAliasUrl = res.links.alternate;

--- a/js/ratings.js
+++ b/js/ratings.js
@@ -289,22 +289,24 @@ function getTomatoAPILink(imdbId) {
 function getTomatoLink(rating, callback) {
     if (!rating.imdbID) {
         callback(rating);
+        return null;
     }
+    var tomatoAliasUrl = null;
     var imdbID = rating.imdbID.slice(2); //convert tt123456 -> 123456
     var cached = checkCache(rating.title);
     if (cached.inCache && cached.cachedVal.tomatoAliasUrl !== undefined) {
-        return cached.cachedVal.tomatoAliasUrl;
+        tomatoAliasUrl = cached.cachedVal.tomatoAliasUrl;
     } else {
         $.get(getTomatoAPILink(imdbID), function(res) {
-            var tomatoAliasUrl = null;
             if (res.error === undefined) {
                 tomatoAliasUrl = res.links.alternate;
+                rating = addTomatoAliasCache(rating.title, tomatoAliasUrl);
             }
-            rating = addTomatoAliasCache(rating.title, tomatoAliasUrl);
-            callback(rating);
         }, "json");
     }
-    return null;
+
+    callback(rating);
+    return tomatoAliasUrl;
 }
 
 /*

--- a/js/ratings.js
+++ b/js/ratings.js
@@ -296,14 +296,16 @@ function getTomatoLink(rating, callback) {
     if (cached.inCache && cached.cachedVal.tomatoAliasUrl !== undefined) {
         callback(rating);
     } else {
+        var tomatoAliasUrl = null;
         $.get(getTomatoAPILink(imdbID), function(res) {
             if (res.error === undefined) {
-                var tomatoAliasUrl = res.links.alternate;
-                rating = addTomatoAliasCache(rating.title, tomatoAliasUrl);
+                tomatoAliasUrl = res.links.alternate;
             }
-
+        }, "json")
+        .always(function() {
+            rating = addTomatoAliasCache(rating.title, tomatoAliasUrl);
             callback(rating);
-        }, "json");
+        });
     }
 }
 

--- a/js/ratings.js
+++ b/js/ratings.js
@@ -289,24 +289,22 @@ function getTomatoAPILink(imdbId) {
 function getTomatoLink(rating, callback) {
     if (!rating.imdbID) {
         callback(rating);
-        return null;
+        return;
     }
-    var tomatoAliasUrl = null;
     var imdbID = rating.imdbID.slice(2); //convert tt123456 -> 123456
     var cached = checkCache(rating.title);
     if (cached.inCache && cached.cachedVal.tomatoAliasUrl !== undefined) {
-        tomatoAliasUrl = cached.cachedVal.tomatoAliasUrl;
+        callback(rating);
     } else {
         $.get(getTomatoAPILink(imdbID), function(res) {
             if (res.error === undefined) {
-                tomatoAliasUrl = res.links.alternate;
+                var tomatoAliasUrl = res.links.alternate;
                 rating = addTomatoAliasCache(rating.title, tomatoAliasUrl);
             }
+
+            callback(rating);
         }, "json");
     }
-
-    callback(rating);
-    return tomatoAliasUrl;
 }
 
 /*


### PR DESCRIPTION
I fixed 2 issues:

When `rating.imdbID` was null, the line `rating.imdbID.slice(2)` would throw `Uncaught TypeError: Cannot read property 'slice' of null`. I'm now returning null before hitting this line.

If `tomatoAliasUrl` was coming from the cache we would not call `callback(rating);`, I'm now calling it consistently.